### PR TITLE
Add managed domains flag

### DIFF
--- a/charts/cert-broker/templates/deployment.yaml
+++ b/charts/cert-broker/templates/deployment.yaml
@@ -47,6 +47,12 @@ spec:
           - --acme-dns01-provider={{ .Values.certmanager.acmeDNS01Provider }}
           - --update-ingress={{ .Values.certmanager.updateIngress }}
           - --leader-election={{ .Values.certmanager.leaderElection }}
+          {{- if not .Values.certbroker.managedDomains }}
+          {{- required "Managed domains must be provided" .Values.certbroker.managedDomains }}
+          {{- end }}
+          {{- range .Values.certbroker.managedDomains }}
+          - --managed-domain={{ . }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:

--- a/cmd/controller-manager.go
+++ b/cmd/controller-manager.go
@@ -111,6 +111,7 @@ func (cb *CertBroker) startCertBorker(out, errOut io.Writer, stopCh <-chan struc
 			IngressSync:     targetClientInformerFactory.Extensions().V1beta1().Ingresses().Informer().HasSynced,
 		},
 		ingressTemplate,
+		cb.ControllerOptions.ManagedDomains,
 	)
 
 	ingressCleaner := cleaner.NewController(
@@ -195,7 +196,7 @@ func (cb *CertBroker) startCertBorker(out, errOut io.Writer, stopCh <-chan struc
 		go func() {
 			defer controllerWg.Done()
 			controllerWg.Add(1)
-			if err := eventController.Start(int(cb.ControllerOptions.CleanupWorkerCount), stopCh); err != nil {
+			if err := eventController.Start(int(cb.ControllerOptions.EventWorkerCount), stopCh); err != nil {
 				logger.Errorf("error starting the event controlle: %v", err)
 			}
 		}()

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -30,6 +30,8 @@ const (
 	defaultAcmeChallenge        = "dns01"
 )
 
+var defaultManagedDomains = []string{}
+
 // Options represent configuration settings for a running instance of Cert-Broker.
 type Options struct {
 	TargetClusterKubeconf  string
@@ -38,11 +40,13 @@ type Options struct {
 	ClusterIssuer          string
 	AcmeChallengeType      string
 	AcmeDNS01Provider      string
+	ManagedDomains         []string
 	UpdateControlIngress   bool
 	LeaderElection         bool
 	IngressWorkerCount     uint
 	SecretWorkerCount      uint
 	CleanupWorkerCount     uint
+	EventWorkerCount       uint
 	SyncInterval           time.Duration
 }
 
@@ -59,6 +63,8 @@ func (options *Options) addFlags(fs *pflag.FlagSet) {
 		"ACME challenge type to be set in replicated Ingress")
 	fs.StringVar(&options.AcmeDNS01Provider, "acme-dns01-provider", "", ""+
 		"Name of the DNS01 provider if ACME challenge type is DNS01")
+	fs.StringArrayVar(&options.ManagedDomains, "managed-domain", defaultManagedDomains, ""+
+		"A list of domains being considerd by Cert-Broker. Domains apart from that list will be ignored.")
 	fs.BoolVar(&options.UpdateControlIngress, "update-ingress", defaultUpdateContronIngress, ""+
 		"Determins whether existing Ingress resources in the control cluster should be updated."+
 		"Needed if issuer information has changed.")
@@ -72,6 +78,8 @@ func (options *Options) addFlags(fs *pflag.FlagSet) {
 		"Worker count for the Secret replication")
 	fs.UintVar(&options.CleanupWorkerCount, "cleanup-workers", defaultCleanupCount, ""+
 		"Worker count for the Ingress clean-up")
+	fs.UintVar(&options.EventWorkerCount, "event-workers", defaultWorkerCount, ""+
+		"Worker count for the Event propagation")
 }
 
 // NewControllerOptions adds configured flags and returns a pointer to a newly created Options struct.

--- a/pkg/cleaner/controller.go
+++ b/pkg/cleaner/controller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gardener/cert-broker/pkg/utils"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -27,8 +28,6 @@ import (
 	lv1beta1 "k8s.io/client-go/listers/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -173,6 +172,9 @@ func (c *Controller) syncHandler(key string) (bool, error) {
 
 	controlIngress, err := c.controlCtx.IngressLister.Ingresses(namespace).Get(name)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
 		return true, err
 	}
 

--- a/pkg/events/sync.go
+++ b/pkg/events/sync.go
@@ -73,7 +73,7 @@ func NewController(controlCtx *ControlClusterContext, targetCtx *TargetClusterCo
 		controlCtx: controlCtx,
 		targetCtx:  targetCtx,
 		workqueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Events"),
-		recorder:   utils.CreateRecorder(targetCtx.Client, logger, "Cert-Broker-Ingress-Controll"),
+		recorder:   utils.CreateRecorder(targetCtx.Client, logger, "Cert-Broker-Ingress-Control"),
 	}
 	handler.controlCtx.EventInformer.AddEventHandler(&cache.FilteringResourceEventHandler{
 		FilterFunc: certificateIsInvolved,


### PR DESCRIPTION
This PR adds the `--managedDomain` flag to Cert-Broker.
Only quoted domains will be considered when replicating the TLS list from an Ingress in the target cluster to an Ingress in the control cluster.