### PR TITLE
Upgrade golang version to 1.11.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -16,9 +16,9 @@ cert-broker:
             tag_as_latest: true
     steps:
       check:
-        image: 'golang:1.11.1'
+        image: 'golang:1.11.5'
       test:
-        image: 'golang:1.11.1'
+        image: 'golang:1.11.5'
   variants:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.11.4 AS builder
+FROM golang:1.11.5 AS builder
 WORKDIR /go/src/github.com/gardener/cert-broker
 COPY . .
 


### PR DESCRIPTION
**What this PR does / why we need it**:

> We have just released Go 1.11.5 and Go 1.10.8 to address a recently reported security issue. We recommend that all users update to one of these releases (if you’re not sure which, choose Go 1.11.5).
>
> This DoS vulnerability in the crypto/elliptic implementations of the P-521 and P-384 elliptic curves may let an attacker craft inputs that consume excessive amounts of CPU.
>
> These inputs might be delivered via TLS handshakes, X.509 certificates, JWT tokens, ECDH shares or ECDSA signatures. In some cases, if an ECDH private key is reused more than once, the attack can also lead to key recovery.
>
> The issue is CVE-2019-6486.


**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

n/a

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```

/cc @ThormaehlenFred